### PR TITLE
Add GitHub Actions and widget test

### DIFF
--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -1,0 +1,25 @@
+name: Flutter CI
+
+on:
+  push:
+    paths:
+      - '**.dart'
+      - pubspec.yaml
+      - .github/workflows/flutter.yml
+  pull_request:
+    paths:
+      - '**.dart'
+      - pubspec.yaml
+      - .github/workflows/flutter.yml
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: 'stable'
+      - run: flutter pub get
+      - run: flutter analyze
+      - run: flutter test

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -23,12 +23,18 @@ class MyApp extends StatelessWidget {
     return MaterialApp(
       title: "How's Elsa Day?",
       theme: ThemeData(primarySwatch: Colors.pink),
-      home: MoodSliderScreen(),
+      home: const MoodSliderScreen(),
     );
   }
 }
 
 class MoodSliderScreen extends StatefulWidget {
+  final FirebaseFirestore firestore;
+
+  const MoodSliderScreen({Key? key, FirebaseFirestore? firestore})
+      : firestore = firestore ?? FirebaseFirestore.instance,
+        super(key: key);
+
   @override
   _MoodSliderScreenState createState() => _MoodSliderScreenState();
 }
@@ -49,7 +55,7 @@ class _MoodSliderScreenState extends State<MoodSliderScreen> {
       'timestamp': Timestamp.now(),
     };
 
-    await FirebaseFirestore.instance.collection('moods').add(moodData);
+    await widget.firestore.collection('moods').add(moodData);
 
     ScaffoldMessenger.of(
       context,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -40,6 +40,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
+  fake_cloud_firestore: ^2.4.0
 
   # The "flutter_lints" package below contains a set of recommended lints to
   # encourage good coding practices. The lint set provided by the package is

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1,30 +1,33 @@
-// This is a basic Flutter widget test.
-//
-// To perform an interaction with a widget in your test, use the WidgetTester
-// utility in the flutter_test package. For example, you can send tap and scroll
-// gestures. You can also use WidgetTester to find child widgets in the widget
-// tree, read text, and verify that the values of widget properties are correct.
-
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:howelsaday/main.dart';
 
 void main() {
-  testWidgets('Counter increments smoke test', (WidgetTester tester) async {
-    // Build our app and trigger a frame.
-    await tester.pumpWidget(const MyApp());
+  testWidgets('slider updates mood and shows snackbar', (WidgetTester tester) async {
+    final firestore = FakeFirebaseFirestore();
 
-    // Verify that our counter starts at 0.
-    expect(find.text('0'), findsOneWidget);
-    expect(find.text('1'), findsNothing);
+    await tester.pumpWidget(
+      MaterialApp(home: MoodSliderScreen(firestore: firestore)),
+    );
 
-    // Tap the '+' icon and trigger a frame.
-    await tester.tap(find.byIcon(Icons.add));
+    // Initial mood should be neutral
+    expect(find.text('😐 Bình thường'), findsOneWidget);
+
+    // Update slider value via callback
+    final sliderFinder = find.byType(Slider);
+    final Slider slider = tester.widget(sliderFinder);
+    slider.onChanged?.call(80);
     await tester.pump();
 
-    // Verify that our counter has incremented.
-    expect(find.text('0'), findsNothing);
-    expect(find.text('1'), findsOneWidget);
+    // Mood text should reflect new value
+    expect(find.text('😊 Vui'), findsOneWidget);
+
+    // Tap send button to trigger SnackBar
+    await tester.tap(find.text('Gửi cảm xúc 💌'));
+    await tester.pump();
+
+    expect(find.text('Đã gửi cảm xúc: 😊 Vui'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- add Flutter CI workflow running `flutter analyze` and `flutter test`
- inject Firestore into `MoodSliderScreen` for testability
- update `pubspec.yaml` with `fake_cloud_firestore`
- replace widget test with slider/snackbar test

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846547d496483299a63d342bc990521